### PR TITLE
TEST-1: Mock issue code optimization

### DIFF
--- a/src/ops/create.rs
+++ b/src/ops/create.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -96,30 +96,29 @@ fn build_pack_order(mut files: Vec<PathBuf>, ks: &KeyStore) -> Vec<PathBuf> {
             .map(|n| n.to_string_lossy().to_ascii_lowercase())
             .unwrap_or_default()
     });
+    let normalized_names: Vec<String> = files.iter().map(|p| lower_name(p)).collect();
 
     let mut out = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
 
     // 1) CNMT-driven NCA order (matches python ncalist_bycnmt behavior).
-    let mut id_to_file: Vec<(String, PathBuf)> = Vec::new();
-    for p in &files {
-        let name = lower_name(p);
+    let mut id_to_file: HashMap<String, PathBuf> = HashMap::new();
+    for (p, name) in files.iter().zip(normalized_names.iter()) {
         if name.ends_with(".nca") {
             if let Some(stem) = name.strip_suffix(".nca") {
-                id_to_file.push((stem.to_string(), p.clone()));
+                id_to_file.entry(stem.to_string()).or_insert_with(|| p.clone());
             }
         } else if name.ends_with(".ncz") {
             if let Some(stem) = name.strip_suffix(".ncz") {
-                id_to_file.push((stem.to_string(), p.clone()));
+                id_to_file.entry(stem.to_string()).or_insert_with(|| p.clone());
             }
         }
     }
-    for p in &files {
-        let name = lower_name(p);
+    for (p, name) in files.iter().zip(normalized_names.iter()) {
         if name.ends_with(".cnmt.nca") {
             if let Some(cnmt) = parse_cnmt_from_meta_nca_file(p, ks) {
                 for nca_id in cnmt.nca_ids() {
-                    if let Some((_, fp)) = id_to_file.iter().find(|(id, _)| id == &nca_id) {
+                    if let Some(fp) = id_to_file.get(&nca_id) {
                         push_unique(&mut out, &mut seen, fp.clone());
                     }
                 }
@@ -129,46 +128,43 @@ fn build_pack_order(mut files: Vec<PathBuf>, ks: &KeyStore) -> Vec<PathBuf> {
     // Fallback when CNMT parsing fails: place non-meta NCAs first (largest-first),
     // then meta NCA, mirroring python create behavior on these split folders.
     if out.is_empty() {
-        let mut non_meta: Vec<(u64, PathBuf)> = files
+        let mut non_meta: Vec<(u64, usize)> = files
             .iter()
+            .enumerate()
             .filter(|p| {
-                let n = lower_name(p);
+                let n = &normalized_names[p.0];
                 n.ends_with(".nca") && !n.ends_with(".cnmt.nca")
             })
-            .map(|p| (p.metadata().map(|m| m.len()).unwrap_or(0), p.clone()))
+            .map(|(idx, p)| (p.metadata().map(|m| m.len()).unwrap_or(0), idx))
             .collect();
         non_meta.sort_by(|a, b| {
             b.0.cmp(&a.0)
-                .then_with(|| lower_name(&a.1).cmp(&lower_name(&b.1)))
+                .then_with(|| normalized_names[a.1].cmp(&normalized_names[b.1]))
         });
-        for (_, p) in non_meta {
-            push_unique(&mut out, &mut seen, p);
+        for (_, idx) in non_meta {
+            push_unique(&mut out, &mut seen, files[idx].clone());
         }
     }
     // 2) Meta NCA(s)
-    for p in &files {
-        let name = lower_name(p);
+    for (p, name) in files.iter().zip(normalized_names.iter()) {
         if name.ends_with(".cnmt.nca") {
             push_unique(&mut out, &mut seen, p.clone());
         }
     }
     // 3) .cnmt xml/plain
-    for p in &files {
-        let name = lower_name(p);
+    for (p, name) in files.iter().zip(normalized_names.iter()) {
         if name.ends_with(".cnmt") || name.ends_with(".cnmt.xml") {
             push_unique(&mut out, &mut seen, p.clone());
         }
     }
     // 4) Images
-    for p in &files {
-        let name = lower_name(p);
+    for (p, name) in files.iter().zip(normalized_names.iter()) {
         if name.ends_with(".jpg") || name.ends_with(".jpeg") || name.ends_with(".png") {
             push_unique(&mut out, &mut seen, p.clone());
         }
     }
     // 5) Tickets/certs
-    for p in &files {
-        let name = lower_name(p);
+    for (p, name) in files.iter().zip(normalized_names.iter()) {
         if name.ends_with(".tik") || name.ends_with(".cert") {
             push_unique(&mut out, &mut seen, p.clone());
         }
@@ -321,5 +317,47 @@ fn aes_ctr_transform_in_place(key: &[u8; 16], nonce8: &[u8; 8], file_offset: u64
             cached_block_index = block_index;
         }
         *byte ^= cached_keystream[byte_in_block];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(path: &Path, size: usize) {
+        let mut data = vec![0u8; size];
+        if size > 0 {
+            data[0] = 1;
+        }
+        std::fs::write(path, data).unwrap();
+    }
+
+    #[test]
+    fn build_pack_order_fallback_is_size_then_category_deterministic() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_cnmt = dir.path().join("a.cnmt.nca");
+        let b_nca = dir.path().join("b.nca");
+        let c_nca = dir.path().join("c.nca");
+        let d_tik = dir.path().join("d.tik");
+        let e_jpg = dir.path().join("e.jpg");
+        let z_bin = dir.path().join("z.bin");
+
+        write_file(&a_cnmt, 10);
+        write_file(&b_nca, 30);
+        write_file(&c_nca, 20);
+        write_file(&d_tik, 1);
+        write_file(&e_jpg, 1);
+        write_file(&z_bin, 1);
+
+        let ks = KeyStore::from_string("").unwrap();
+        let files = vec![z_bin, d_tik, c_nca, e_jpg, b_nca, a_cnmt];
+        let ordered = build_pack_order(files, &ks);
+
+        let names: Vec<String> = ordered
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(names, vec!["b.nca", "c.nca", "a.cnmt.nca", "e.jpg", "d.tik", "z.bin"]);
     }
 }


### PR DESCRIPTION
## Summary
- Optimized `build_pack_order` in `src/ops/create.rs` by precomputing normalized filenames once and reusing them across all classification passes.
- Replaced CNMT lookup from linear `Vec` scans to a `HashMap` keyed by content ID, reducing repeated O(n) lookups during pack-order resolution.
- Added a deterministic unit test for fallback ordering (`size -> category -> remainder`) to guard behavior while improving performance.

## Why
The previous implementation repeatedly rebuilt lowercase filenames and repeatedly scanned vectors when resolving CNMT-driven NCA order. This change reduces avoidable allocations and repeated scans while preserving output order semantics.

## Validation
- `/workspace/.opencode-home/.cargo/bin/cargo build` ✅
- `/workspace/.opencode-home/.cargo/bin/cargo test` ✅ (31 tests passed in lib target, 31 tests passed in bin target)