### PR TITLE
TEST-1: Mock issue code optimization

### DIFF
--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -8,7 +8,8 @@ pub fn align_up(n: u64, align: u64) -> u64 {
 /// How many padding bytes are needed to align `n` to `align`.
 #[inline]
 pub fn padding_needed(n: u64, align: u64) -> u64 {
-    align_up(n, align) - n
+    debug_assert!(align > 0 && align.is_power_of_two());
+    n.wrapping_neg() & (align - 1)
 }
 
 /// Round `n` down to the previous multiple of `align`.


### PR DESCRIPTION
## Summary
- Optimized `padding_needed` in `src/util/align.rs` to use a direct bitwise power-of-two padding formula (`n.wrapping_neg() & (align - 1)`) instead of computing through `align_up`.
- Kept behavior equivalent for existing call sites and preserved power-of-two alignment guards with `debug_assert!`.

## Validation
- `"/workspace/.opencode-home/.cargo/bin/cargo" check`
- `"/workspace/.opencode-home/.cargo/bin/cargo" test`
- Result: passed (all tests green).