### PR TITLE
TEST-1: Mock issue code optimization

### DIFF
--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -475,6 +475,25 @@ fn build_nsp_output(
     let pb = progress::file_progress(total, "Building NSP");
 
     let mut out = BufWriter::new(File::create(output_path)?);
+    let mut source_readers: HashMap<String, BufReader<File>> = HashMap::new();
+
+    fn copy_from_source(
+        readers: &mut HashMap<String, BufReader<File>>,
+        source_path: &str,
+        abs_offset: u64,
+        size: u64,
+        out: &mut BufWriter<File>,
+        pb: &indicatif::ProgressBar,
+    ) -> Result<()> {
+        use std::collections::hash_map::Entry;
+
+        let src = match readers.entry(source_path.to_string()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(BufReader::new(File::open(source_path)?)),
+        };
+        uio::copy_section(src, out, abs_offset, size, Some(pb))?;
+        Ok(())
+    }
 
     // Write PFS0 header
     out.write_all(&header)?;
@@ -491,17 +510,35 @@ fn build_nsp_output(
                     Some(*nca)
                 };
                 if let Some(entry) = to_write {
-                    let mut src = BufReader::new(File::open(&entry.source_path)?);
-                    uio::copy_section(&mut src, &mut out, entry.abs_offset, entry.size, Some(&pb))?;
+                    copy_from_source(
+                        &mut source_readers,
+                        &entry.source_path,
+                        entry.abs_offset,
+                        entry.size,
+                        &mut out,
+                        &pb,
+                    )?;
                 }
             }
             Item::Ticket(tik) => {
-                let mut src = BufReader::new(File::open(&tik.source_path)?);
-                uio::copy_section(&mut src, &mut out, tik.abs_offset, tik.size, Some(&pb))?;
+                copy_from_source(
+                    &mut source_readers,
+                    &tik.source_path,
+                    tik.abs_offset,
+                    tik.size,
+                    &mut out,
+                    &pb,
+                )?;
             }
             Item::Cert(cert) => {
-                let mut src = BufReader::new(File::open(&cert.source_path)?);
-                uio::copy_section(&mut src, &mut out, cert.abs_offset, cert.size, Some(&pb))?;
+                copy_from_source(
+                    &mut source_readers,
+                    &cert.source_path,
+                    cert.abs_offset,
+                    cert.size,
+                    &mut out,
+                    &pb,
+                )?;
             }
             Item::Xml(xml) => {
                 if python_direct_multi_mode && !xml.source_is_nsp_like {
@@ -511,8 +548,14 @@ fn build_nsp_output(
                     out.write_all(bytes)?;
                     pb.inc(bytes.len() as u64);
                 } else if let (Some(source_path), Some(abs_offset)) = (&xml.source_path, xml.abs_offset) {
-                    let mut src = BufReader::new(File::open(source_path)?);
-                    uio::copy_section(&mut src, &mut out, abs_offset, xml.size, Some(&pb))?;
+                    copy_from_source(
+                        &mut source_readers,
+                        source_path,
+                        abs_offset,
+                        xml.size,
+                        &mut out,
+                        &pb,
+                    )?;
                 }
             }
         }


### PR DESCRIPTION
## What changed
- Updated `src/ops/merge.rs` to optimize merge path I/O behavior by reusing buffered source file readers during NSP output generation.
- Introduced a local `copy_from_source` helper in `build_nsp_output` to centralize section-copy logic across NCAs, tickets, certs, and XML payloads.

## Why
- Reopening source files for every item copy adds avoidable overhead in large merge workloads.
- Reusing readers reduces repeated open/seek setup, improving throughput while preserving output ordering and behavior.

## Validation
- `cargo build --all-targets` (pass)
- `cargo test` (pass)